### PR TITLE
Fix pyarrow-fastparquet compatibility problem in #5656

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -590,6 +590,8 @@ def apply_filters(parts, statistics, filters):
                         and max > value
                         or operator == ">="
                         and max >= value
+                        or operator == "in"
+                        and any(min <= item <= max for item in value)
                     ):
                         out_parts.append(part)
                         out_statistics.append(stats)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -117,11 +117,20 @@ def read_parquet(
         non-index fields will be read (as determined by the pandas parquet
         metadata, if present). Provide a single field name instead of a list to
         read in the data as a Series.
-    filters : list
-        List of filters to apply, like ``[('x', '>', 0), ...]``. This
-         implements row-group (partition) -level filtering only, i.e., to
-        prevent the loading of some chunks of the data, and only if relevant
-        statistics have been included in the metadata.
+    filters : Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]]
+        List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
+        implements partition-level (hive) filtering only, i.e., to prevent the
+        loading of some row-groups and/or files.
+
+        Predicates can be expressed in disjunctive normal form (DNF). This means
+        that the innermost tuple describes a single column predicate. These
+        inner predicates are combined with an AND conjunction into a larger
+        predicate. The outer-most list then combines all of the combined
+        filters with an OR disjunction.
+
+        Predicates can also be expressed as a List[Tuple]. These are evaluated
+        as an AND conjunction. To express OR in predictates, one must use the
+        (preferred) List[List[Tuple]] notation.
     index : string, list, False or None (default)
         Field name(s) to use as the output frame index. By default will be
         inferred from the pandas parquet file metadata (if present). Use False
@@ -557,7 +566,19 @@ def apply_filters(parts, statistics, filters):
     statistics: List[dict]
         List of statistics for each part, including min and max values
     filters: Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]]
-        List of filters to apply, like [[('x', '=', 0), ...], ...]
+        List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
+        implements partition-level (hive) filtering only, i.e., to prevent the
+        loading of some row-groups and/or files.
+
+        Predicates can be expressed in disjunctive normal form (DNF). This means
+        that the innermost tuple describes a single column predicate. These
+        inner predicates are combined with an AND conjunction into a larger
+        predicate. The outer-most list then combines all of the combined
+        filters with an OR disjunction.
+
+        Predicates can also be expressed as a List[Tuple]. These are evaluated
+        as an AND conjunction. To express OR in predictates, one must use the
+        (preferred) List[List[Tuple]] notation.
 
     Returns
     -------

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -269,25 +269,40 @@ class FastParquetEngine(Engine):
             # make statistics conform in layout
             for (i, row_group) in enumerate(pf.row_groups):
                 s = {"num-rows": row_group.num_rows, "columns": []}
-                for col in pf.columns:
+                for i_col, col in enumerate(pf.columns):
                     if col not in skip_cols:
                         d = {"name": col}
+                        cs_min = None
+                        cs_max = None
                         if pf.statistics["min"][col][0] is not None:
                             cs_min = pf.statistics["min"][col][i]
                             cs_max = pf.statistics["max"][col][i]
-                            if None in [cs_min, cs_max] and i == 0:
-                                skip_cols.add(col)
-                                continue
-                            if isinstance(cs_min, np.datetime64):
-                                cs_min = pd.Timestamp(cs_min)
-                                cs_max = pd.Timestamp(cs_max)
-                            d.update(
-                                {
-                                    "min": cs_min,
-                                    "max": cs_max,
-                                    "null_count": pf.statistics["null_count"][col][i],
-                                }
-                            )
+                        elif (
+                            dtypes[col] == "object"
+                            and row_group.columns[i_col].meta_data.statistics
+                        ):
+                            cs_min = row_group.columns[
+                                i_col
+                            ].meta_data.statistics.min_value
+                            cs_max = row_group.columns[
+                                i_col
+                            ].meta_data.statistics.max_value
+                            if isinstance(cs_min, (bytes, bytearray)):
+                                cs_min = cs_min.decode("utf-8")
+                                cs_max = cs_max.decode("utf-8")
+                        if None in [cs_min, cs_max] and i == 0:
+                            skip_cols.add(col)
+                            continue
+                        if isinstance(cs_min, np.datetime64):
+                            cs_min = pd.Timestamp(cs_min)
+                            cs_max = pd.Timestamp(cs_max)
+                        d.update(
+                            {
+                                "min": cs_min,
+                                "max": cs_max,
+                                "null_count": pf.statistics["null_count"][col][i],
+                            }
+                        )
                         s["columns"].append(d)
                 # Need this to filter out partitioned-on categorical columns
                 s["filter"] = fastparquet.api.filter_out_cats(row_group, filters)

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1084,7 +1084,7 @@ def test_partition_on_string(tmpdir, partition_on):
 
 
 @write_read_engines_xfail
-def test_filters(tmpdir, write_engine, read_engine):
+def test_filters_categorical(tmpdir, write_engine, read_engine):
     tmpdir = str(tmpdir)
     cats = ["2018-01-01", "2018-01-02", "2018-01-03", "2018-01-04"]
     dftest = pd.DataFrame(
@@ -1101,25 +1101,25 @@ def test_filters(tmpdir, write_engine, read_engine):
     assert len(ddftest_read) == 2
 
 
-def test_filters_pyarrow(tmpdir):
-    check_pyarrow()
+@write_read_engines_xfail
+def test_filters(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
     df = pd.DataFrame({"x": range(10), "y": list("aabbccddee")})
     ddf = dd.from_pandas(df, npartitions=5)
     assert ddf.npartitions == 5
 
-    ddf.to_parquet(tmp_path, engine="pyarrow")
+    ddf.to_parquet(tmp_path, engine=write_engine)
 
-    a = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("x", ">", 4)])
+    a = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", ">", 4)])
     assert a.npartitions == 3
     assert (a.x > 3).all().compute()
 
-    b = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("y", "==", "c")])
+    b = dd.read_parquet(tmp_path, engine=read_engine, filters=[("y", "==", "c")])
     assert b.npartitions == 1
     assert (b.y == "c").all().compute()
 
     c = dd.read_parquet(
-        tmp_path, engine="pyarrow", filters=[("y", "==", "c"), ("x", ">", 6)]
+        tmp_path, engine=read_engine, filters=[("y", "==", "c"), ("x", ">", 6)]
     )
     assert c.npartitions <= 1
     assert not len(c)
@@ -1127,7 +1127,7 @@ def test_filters_pyarrow(tmpdir):
 
     d = dd.read_parquet(
         tmp_path,
-        engine="pyarrow",
+        engine=read_engine,
         filters=[
             # Select two overlapping ranges
             [("x", ">", 1), ("x", "<", 6)],
@@ -1137,7 +1137,7 @@ def test_filters_pyarrow(tmpdir):
     assert d.npartitions == 3
     assert ((d.x > 1) & (d.x < 8)).all().compute()
 
-    e = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("x", "in", (0, 9))])
+    e = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", "in", (0, 9))])
     assert e.npartitions == 2
     assert ((e.x < 2) | (e.x > 7)).all().compute()
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1125,6 +1125,18 @@ def test_filters_pyarrow(tmpdir):
     assert not len(c)
     assert_eq(c, c)
 
+    d = dd.read_parquet(
+        tmp_path,
+        engine="pyarrow",
+        filters=[
+            # Select two overlapping ranges
+            [("x", ">", 1), ("x", "<", 6)],
+            [("x", ">", 3), ("x", "<", 8)],
+        ],
+    )
+    assert d.npartitions == 3
+    assert ((d.x > 1) & (d.x < 8)).all().compute()
+
 
 @write_read_engines()
 def test_filters_v0(tmpdir, write_engine, read_engine):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -180,7 +180,7 @@ def test_empty(tmpdir, write_engine, read_engine, index):
     assert_eq(ddf, read_df)
 
 
-@write_read_engines_xfail
+@write_read_engines()
 def test_simple(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": ["a", "b", "b"], "b": [4, 5, 6]})
@@ -191,7 +191,7 @@ def test_simple(tmpdir, write_engine, read_engine):
     assert_eq(ddf, read_df)
 
 
-@write_read_engines_xfail
+@write_read_engines()
 def test_delayed_no_metadata(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": ["a", "b", "b"], "b": [4, 5, 6]})
@@ -1101,7 +1101,7 @@ def test_filters_categorical(tmpdir, write_engine, read_engine):
     assert len(ddftest_read) == 2
 
 
-@write_read_engines_xfail
+@write_read_engines()
 def test_filters(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
     df = pd.DataFrame({"x": range(10), "y": list("aabbccddee")})

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1137,6 +1137,10 @@ def test_filters_pyarrow(tmpdir):
     assert d.npartitions == 3
     assert ((d.x > 1) & (d.x < 8)).all().compute()
 
+    e = dd.read_parquet(tmp_path, engine="pyarrow", filters=[("x", "in", (0, 9))])
+    assert e.npartitions == 2
+    assert ((e.x < 2) | (e.x > 7)).all().compute()
+
 
 @write_read_engines()
 def test_filters_v0(tmpdir, write_engine, read_engine):


### PR DESCRIPTION
The changes and discussion in #5656 make it clear that there is a compatibility problem between pyarrow and fastparquet for filtering.  This is a possible fix.  Note that pyarrow seems to leave out the `min` and `max` entries in the column statistics for strings, but it **does** include the byte-encoded values as `min_value` and `max_value`. 

- [ ] Tests added / passed
- [ ] Passes `black dask` / `flake8 dask`
